### PR TITLE
feat: flexible (build-time replaced) api server url

### DIFF
--- a/src/auto/components.auto.d.ts
+++ b/src/auto/components.auto.d.ts
@@ -16,7 +16,6 @@ declare module "@vue/runtime-core" {
         FullScreenCard: typeof import("./../components/Course/FullScreenCard.vue")["default"];
         IconFold: typeof import("./../components/Icon/IconFold.vue")["default"];
         IconStars: typeof import("./../components/Icon/IconStars.vue")["default"];
-        IIonArrowUp: typeof import("~icons/ion/arrow-up")["default"];
         IIonLogoDiscord: typeof import("~icons/ion/logo-discord")["default"];
         Input: typeof import("./../components/Input.vue")["default"];
         IOcticonFilter16: typeof import("~icons/octicon/filter16")["default"];

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -10,3 +10,13 @@ declare module "*.vue" {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare type AnyObj = { [key: string]: any };
+
+interface ImportMetaEnv {
+    readonly API_BASE: string;
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+}
+
+declare const API_BASE: string;

--- a/src/uni.ts
+++ b/src/uni.ts
@@ -7,7 +7,7 @@ import router from "./router";
 
 const store = use_store();
 export const uni = new UniCourse(store.token, {
-    server: "https://api.unicourse.tw",
+    server: API_BASE,
 });
 
 ((login: typeof uni.login) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { ConfigEnv, defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import Pages from "vite-plugin-pages";
 import AutoImport from "unplugin-auto-import/vite";
@@ -6,20 +6,30 @@ import Components from "unplugin-vue-components/vite";
 import Icons from "unplugin-icons/vite";
 import IconsResolver from "unplugin-icons/resolver";
 
-export default defineConfig({
-    plugins: [
-        vue(),
-        Pages(),
-        AutoImport({
-            imports: ["vue", "vue-router", "@vueuse/head"],
-            dts: "./src/auto/imports.auto.d.ts",
-        }),
-        Components({
-            dts: "./src/auto/components.auto.d.ts",
-            resolvers: [IconsResolver()],
-        }),
-        Icons({
-            compiler: "vue3",
-        }),
-    ],
-});
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export default ({ mode }: ConfigEnv) =>
+    defineConfig({
+        plugins: [
+            vue(),
+            Pages(),
+            AutoImport({
+                imports: ["vue", "vue-router", "@vueuse/head"],
+                dts: "./src/auto/imports.auto.d.ts",
+            }),
+            Components({
+                dts: "./src/auto/components.auto.d.ts",
+                resolvers: [IconsResolver()],
+            }),
+            Icons({
+                compiler: "vue3",
+            }),
+        ],
+        define: {
+            API_BASE:
+                mode === "development" && process.env.DEV_API_BASE
+                    ? `"${process.env.DEV_API_BASE}"`
+                    : mode === "production" && process.env.PROD_API_BASE
+                    ? `"${process.env.PROD_API_BASE}"`
+                    : `"https://api.unicourse.tw"`,
+        },
+    });


### PR DESCRIPTION
Replace API Server URL.

- If in `dev` mode (e.g. using `pnpm dev`) and env var `DEV_API_BASE` exists, use `DEV_API_BASE`
- If in `prod` mode (e.g. using `pnpm build`) and env var `PROD_API_BASE` exists, use `PROD_API_BASE`
- Otherwise, use `"https://api.unicourse.tw"`